### PR TITLE
Collect useful modules into separate library binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SITE_SRCS = $(DIAGRAMS) $(DOCS_HELPERS) .version.txt docs/src/shunt docs/src/lib
 RUST_SOURCES = $(shell find docs/mdbook-shunt/src/ -name '*.rs')
 SOURCES = $(shell find -name '*.yue')
 OBJECTS = $(patsubst %.yue,%.lua,$(SOURCES))
-BINARIES = bin/shunt bin/goo bin/snoop
+BINARIES = bin/shunt bin/goo bin/snoop bin/libshunt.lua
 
 NODE_FONTNAME = C059
 EDGE_FONTNAME = $(NODE_FONTNAME)

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,8 @@ shunt/version.lua: .version.txt
 .FORCE:
 .PHONY: .FORCE
 
-release: bin/shunt ./scripts/release bin/snoop
+release: bin/shunt bin/libshunt.lua ./scripts/release bin/snoop
 	./scripts/release bin/shunt
 	./scripts/release bin/snoop
+	./scripts/release bin/libshunt.lua
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LUA = luajit
 DIAGRAM_NAMES = marshal-main marshal-resource_orchestrator marshal-scheduler marshal-schedule_generator marshal-schedule_generator_impl upgrade_listener config_listener
 DIAGRAMS = $(patsubst %,docs/src/reference-materials/state-machine-diagrams/%.mmd,$(DIAGRAM_NAMES))
 DOCS_HELPERS = docs/mdbook-shunt/target/release/mdbook-shunt
-SITE_SRCS = $(DIAGRAMS) $(DOCS_HELPERS) .version.txt docs/src/shunt
+SITE_SRCS = $(DIAGRAMS) $(DOCS_HELPERS) .version.txt docs/src/shunt docs/src/libshunt.lua
 RUST_SOURCES = $(shell find docs/mdbook-shunt/src/ -name '*.rs')
 SOURCES = $(shell find -name '*.yue')
 OBJECTS = $(patsubst %.yue,%.lua,$(SOURCES))
@@ -31,10 +31,13 @@ serve-site: $(SITE_SRCS)
 docs/mdbook-shunt/target/release/mdbook-shunt: docs/mdbook-shunt/Cargo.toml $(RUST_SOURCES)
 	cargo build --release --manifest-path $<
 
+docs/src/libshunt.lua: bin/libshunt.lua
+	cp $< $@
+
 docs/src/shunt: bin/shunt
 	cp $< $@
 
-bin/%: bin/%.lua.packed nitro.lua clap.lua spec.lua
+bin/% bin/%.lua: bin/%.lua.packed nitro.lua clap.lua spec.lua
 # $(LUA) ./nitro.lua $< -o $@
 	cp $< $@
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ bin/%.lua.packed: %.lua $(OBJECTS) moonpack.lua
 shunt.yue: shunt/compat.lua
 
 clean:
-	$(RM) $(OBJECTS) startup.lua packed/shunt shunt.goo $(BINARIES) bin/*
+	$(RM) $(OBJECTS) startup.lua packed/shunt packed/libshunt.lua shunt.goo $(BINARIES) bin/*
 	cargo clean --manifest-path docs/mdbook-shunt/Cargo.toml
 	mdbook clean docs/
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ docs/src/libshunt.lua: bin/libshunt.lua
 docs/src/shunt: bin/shunt
 	cp $< $@
 
-bin/% bin/%.lua: bin/%.lua.packed nitro.lua clap.lua spec.lua
+bin/% bin/%.lua: bin/%.lua.packed nitro.lua shunt/clap.lua shunt/spec.lua
 # $(LUA) ./nitro.lua $< -o $@
 	cp $< $@
 

--- a/libshunt.yue
+++ b/libshunt.yue
@@ -1,12 +1,12 @@
-re_exports =
+to_preload =
   ['libshunt.clap']: -> require 'clap'
   ['libshunt.logger']: -> require 'shunt.logger'
   ['libshunt.quicktype']: -> require 'quicktype'
   ['libshunt.state']: -> require 'shunt.state'
-for lib, src_fn in pairs re_exports
+for lib, src_fn in pairs to_preload
   package.preload[lib] = src_fn
 
 <index>: =>
-  lib_names = [ lib_name for lib_name, _ in pairs re_exports]
+  lib_names = [ lib_name for lib_name, _ in pairs to_preload]
   table.sort lib_names
   error "libshunt modules are accessed by calling `require'\navailable modules:\n  #{table.concat lib_names, '\n  '}"

--- a/libshunt.yue
+++ b/libshunt.yue
@@ -1,12 +1,12 @@
-to_preload =
-  ['libshunt.clap']: -> require 'clap'
+re_exports =
+  ['libshunt.clap']: -> require 'shunt.clap'
   ['libshunt.logger']: -> require 'shunt.logger'
-  ['libshunt.quicktype']: -> require 'quicktype'
+  ['libshunt.quicktype']: -> require 'shunt.quicktype'
   ['libshunt.state']: -> require 'shunt.state'
-for lib, src_fn in pairs to_preload
+for lib, src_fn in pairs re_exports
   package.preload[lib] = src_fn
 
 <index>: =>
-  lib_names = [ lib_name for lib_name, _ in pairs to_preload]
+  lib_names = [ lib_name for lib_name, _ in pairs re_exports]
   table.sort lib_names
   error "libshunt modules are accessed by calling `require'\navailable modules:\n  #{table.concat lib_names, '\n  '}"

--- a/libshunt.yue
+++ b/libshunt.yue
@@ -1,0 +1,12 @@
+re_exports =
+  ['libshunt.clap']: -> require 'clap'
+  ['libshunt.logger']: -> require 'shunt.logger'
+  ['libshunt.quicktype']: -> require 'quicktype'
+  ['libshunt.state']: -> require 'shunt.state'
+for lib, src_fn in pairs re_exports
+  package.preload[lib] = src_fn
+
+<index>: =>
+  lib_names = [ lib_name for lib_name, _ in pairs re_exports]
+  table.sort lib_names
+  error "libshunt modules are accessed by calling `require'\navailable modules:\n  #{table.concat lib_names, '\n  '}"

--- a/scripts/release
+++ b/scripts/release
@@ -23,7 +23,7 @@ cp $1 release/
 pushd release/
 
 git add .
-git commit -S -m "release @$(date +%Y-%m-%d@%H:%M:%S)"
+git commit -S -m "$1 release @$(date +%Y-%m-%d@%H:%M:%S)"
 git push
 
 popd


### PR DESCRIPTION
This PR adds `libshunt`, which is a library of some useful functionality from the `shunt` project. When loaded, the library modifies `package.preload` to make certain modules available. In particular, all of the following are added:

- `libshunt.clap`
- `libshunt.logger`
- `libshunt.quicktype`
- `libshunt.spec`
- `libshunt.state`

Their dependencies are also pulled into the binary, hence the produced `libshunt.lua` is self-contained. The `libshunt.lua` binary is hosted in the root of the docs site.

The creation of this binary is extremely simple; the contained dependencies are not sandboxed. That work may come in a future PR
