### PR TITLE
Move `Self` declaration into quicktype

### DIFF
--- a/docs/src/reference-materials/quicktype-notation/type-aliases.md
+++ b/docs/src/reference-materials/quicktype-notation/type-aliases.md
@@ -12,3 +12,7 @@ For example, a `BinaryTree` could be defined as:
 
 A type alias may have a _disambiguator_ before a literal `.` in its name.
 For example, a station in a marshal’s world-model could be differentiated from a Create station peripheral by calling one `marshal.Station` and the other `peripheral.Station`.
+
+## The `Self` type
+
+The `Self` type is an alias of `some`.

--- a/shunt.yue
+++ b/shunt.yue
@@ -4,7 +4,6 @@ import 'shunt.compat' as :apply_compat, :HOST, :test_compat
 apply_compat!
 
 import 'shunt.quicktype' as :declare_type
-declare_type 'Self', 'some'
 
 import 'shunt.args' as :Args
 import 'shunt.instrument' as :instrument

--- a/shunt/quicktype.yue
+++ b/shunt/quicktype.yue
@@ -1289,6 +1289,8 @@ export declare_type = (name, type_spec) ->
   user_types[name] = parsed_type
   type_checkers[name] = parsed_type\checker!\build!
 
+declare_type 'Self', 'some'
+
 export declare_singleton_type = (value) ->
   if not value?
     error "declare_singleton_type requires a value"


### PR DESCRIPTION
This PR makes the `Self` type available in `libshunt`, the lack of which was causing errors
