### PR TITLE
Add rudamentary replacement json support

### DIFF
--- a/shunt/compat.yue
+++ b/shunt/compat.yue
@@ -239,8 +239,6 @@ export test_compat = ->
           assert v['hell\\o'] == 123, "v.hello incorrect: #{v['hell\\o']}"
           assert v.are == true, "v.are incorrect: #{v.are}"
           assert v.you == false, "v.you incorrect: #{v.you}"
-    * name: 'textutils.deserialise deserialises'
-      check: ->
   failed = false
   for test in *tests
     try

--- a/shunt/compat.yue
+++ b/shunt/compat.yue
@@ -73,6 +73,137 @@ export apply_compat = ->
 
   bit.lshift ??= bit.blshift
 
+  if not textutils?
+    global textutils = {}
+
+  is_list = (t) ->
+    max_key = -1
+    for k, _ in pairs t
+      if 'number' != type k
+        return false
+      if k % 1 != 0
+        return false
+      if k > max_key
+        max_key = k
+    #t == max_key
+
+  textutils.serialise ??= (value, opts) ->
+    if not opts?
+      error 'textutils.serialise must be called with compact:true'
+    if opts.compact != true
+      error 'textutils.serialise must be called with compact:true'
+    if opts.allow_repetitions?
+      error 'textutils.serialise must not be called with allow_repetitions'
+
+    table.concat with {}
+      serialise = (value) ->
+        switch type value
+          when 'nil'
+            [] = 'null'
+          when 'boolean', 'number'
+            [] = tostring value
+          when 'string'
+            [] = '"'
+            [] = value\gsub '"', '\\"'
+            [] = '"'
+          when 'table'
+            if is_list value
+              [] = '['
+              first = true
+              for e in *value
+                if first
+                  first = false
+                else
+                  [] = ','
+                serialise e
+              [] = ']'
+            else
+              [] = '{'
+              first = true
+              for k, v in pairs value
+                if first
+                  first = false
+                else
+                  [] = ','
+                serialise k
+                [] = ':'
+                serialise v
+              [] = '}'
+          else
+            error "cannot serialise a #{type value} as json"
+      serialise value
+
+  textutils.deserialise ??= (raw) ->
+    print "deserialising '#{raw}'..."
+    index = 1
+    deserialise = ->
+      if token = raw\match '^null', index
+        print 'n'
+        index += #token
+        nil
+      else if token = raw\match '^true', index
+        print 't'
+        index += #token
+        true
+      else if token = raw\match '^false', index
+        print 'f'
+        index += #token
+        false
+      else if number = raw\match '^[0-9]+%.[0-9]+', index
+        print 'n'
+        index += #number
+        tonumber number
+      else if number = raw\match '^[0-9]+', index
+        print 'n'
+        index += #number
+        tonumber number
+      else if string = raw\match '^"([^"]*)"', index
+        print 's'
+        index += 2 + #string
+        string
+      else if token = raw\match '^%[', index
+        print 'l'
+        index += 1
+        with {}
+          first = true
+          while not raw\match '^]', index
+            if first
+              first = false
+            else if raw\match '^,', index
+              index += 1
+            else
+              error "expected `,` at position #{index}"
+            print 'inner'
+            [] = deserialise!
+          index += 1
+      else if raw\match '^{', index
+        print 'm'
+        with {}
+          index += 1
+          first = true
+          while not raw\match '^}', index
+            if first
+              first = false
+            else if raw\match '^,', index
+              index += 1
+            else
+              error "expected `,` at position #{index}"
+
+            key = deserialise!
+            if raw\match '^:', index
+              index += 1
+            else
+              error "expected `:` at position #{index}"
+            [key] = deserialise!
+          index += 1
+      else
+        error "unexpected character #{raw\sub index, index} at #{index}"
+    ret = deserialise!
+    print tostring ret
+    if #raw != index - 1
+      error "deserialisation ended early (parsed #{index} of #{#raw})"
+    ret
+
 export test_compat = ->
   if not compat_applied
     error 'call apply_compat before testing compat'
@@ -99,6 +230,28 @@ export test_compat = ->
         host = detect_host!
         if HOST != host
           error "host detection heuristic changed"
+    * name: 'json roundtrip'
+      check: ->
+        case = (value, check) ->
+          check ??= (v) ->
+            assert v == value, "expected #{value} but got #{v}"
+          check textutils.deserialise textutils.serialise value, compact: true
+        case nil
+        case { '123', '321' }, (v) ->
+          assert v[1] == '123', "v[1] incorrect: #{v[1]}"
+          assert v[2] == '321', "v[2] incorrect: #{v[2]}"
+        case {
+          world: 'how'
+          ['hell\\o']: 123
+          are: true
+          you: false
+        }, (v) ->
+          assert v.world == 'how', "v.world incorrect: #{v.world}"
+          assert v['hell\\o'] == 123, "v.hello incorrect: #{v['hell\\o']}"
+          assert v.are == true, "v.are incorrect: #{v.are}"
+          assert v.you == false, "v.you incorrect: #{v.you}"
+    * name: 'textutils.deserialise deserialises'
+      check: ->
   failed = false
   for test in *tests
     try

--- a/shunt/compat.yue
+++ b/shunt/compat.yue
@@ -134,35 +134,27 @@ export apply_compat = ->
       serialise value
 
   textutils.deserialise ??= (raw) ->
-    print "deserialising '#{raw}'..."
     index = 1
     deserialise = ->
       if token = raw\match '^null', index
-        print 'n'
         index += #token
         nil
       else if token = raw\match '^true', index
-        print 't'
         index += #token
         true
       else if token = raw\match '^false', index
-        print 'f'
         index += #token
         false
       else if number = raw\match '^[0-9]+%.[0-9]+', index
-        print 'n'
         index += #number
         tonumber number
       else if number = raw\match '^[0-9]+', index
-        print 'n'
         index += #number
         tonumber number
       else if string = raw\match '^"([^"]*)"', index
-        print 's'
         index += 2 + #string
         string
       else if token = raw\match '^%[', index
-        print 'l'
         index += 1
         with {}
           first = true
@@ -173,11 +165,9 @@ export apply_compat = ->
               index += 1
             else
               error "expected `,` at position #{index}"
-            print 'inner'
             [] = deserialise!
           index += 1
       else if raw\match '^{', index
-        print 'm'
         with {}
           index += 1
           first = true
@@ -199,7 +189,6 @@ export apply_compat = ->
       else
         error "unexpected character #{raw\sub index, index} at #{index}"
     ret = deserialise!
-    print tostring ret
     if #raw != index - 1
       error "deserialisation ended early (parsed #{index} of #{#raw})"
     ret


### PR DESCRIPTION
This PR adds rudamentary replacements for `textutils.serialise` and `textutils.deserialise` for the purpose of testing
