### PR TITLE
Add implicit lazy-loading to `libshunt`

### DIFF
--- a/libshunt.yue
+++ b/libshunt.yue
@@ -1,14 +1,21 @@
-re_exports =
-  ['libshunt.clap']: -> require 'shunt.clap'
-  ['libshunt.logger']: -> require 'shunt.logger'
-  ['libshunt.quicktype']: -> require 'shunt.quicktype'
-  ['libshunt.spec']: -> require 'shunt.spec'
-  ['libshunt.state']: -> require 'shunt.state'
-  ['libshunt.writelite']: -> require 'shunt.writelite'
-for lib, src_fn in pairs re_exports
-  package.preload[lib] = src_fn
+Lazy = (fn) -> with <>: {}
+  .<index> = (key) =>
+    @![key]
+  .<newindex> = ->
+    error "cannot assign field"
+  .<call> = =>
+    t = fn!
+    if 'table' != type t
+      error 'internal error: loader function did not return table'
+    import 'shunt.spec' as :repr
+    @.<> = t.<>
+    for k, v in pairs t
+      @[k] = v
+    @
 
-<index>: =>
-  lib_names = [ lib_name for lib_name, _ in pairs re_exports]
-  table.sort lib_names
-  error "libshunt modules are accessed by calling `require'\navailable modules:\n  #{table.concat lib_names, '\n  '}"
+export clap = Lazy -> require 'shunt.clap'
+export logger = Lazy -> require 'shunt.logger'
+export quicktype = Lazy -> require 'shunt.quicktype'
+export spec = Lazy -> require 'shunt.spec'
+export state = Lazy -> require 'shunt.state'
+export writelite = Lazy -> require 'shunt.writelite'


### PR DESCRIPTION
This PR modifies the `libshunt` import API to remove the strange impure import pattern previously used. In particular, this PR makes the following change:

```moonscript
-- Old API
require 'libshunt'
local foo = require('libshunt.foo')

-- NewA API
local libshunt = require('libshunt')
local bar = libshunt.foo
    .bar -- Module foo lazily loaded at this point
```

All top-level modules can be found by enumeration with `pairs`:

```lua
for k, v in pairs(libshunt) do
    print(k, v)
end
```

Once a module is indexed, it is loaded, allowing the user to inspect the symbols as above. To force a module to be loaded (e.g. before indexing any symbols), the module may be called as a method. This is _not_ required under typical usage.

```lua
for k, v in pairs(libshunt:foo()) do
    print(k, v)
end
```
